### PR TITLE
Fix: Update HTML title to reflect application name

### DIFF
--- a/collaborative-assistant-frontend/index.html
+++ b/collaborative-assistant-frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>Collaborative Assistant System</title>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
Changed the default Vite/React/TS title in `collaborative-assistant-frontend/index.html` to 'Collaborative Assistant System' as per issue #15.